### PR TITLE
feat: send total pages in header

### DIFF
--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -14,6 +14,7 @@ import {
   UseInterceptors,
   Query,
   StreamableFile,
+  Res,
 } from '@nestjs/common';
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
 import {
@@ -54,6 +55,7 @@ import { ApplicationListQueryDto } from 'src/schedule/dto/req/application-list-q
 import { EXCEL_VALIDATION_CONSTANTS } from '@lib/excel-parser/constants/room-assignment-parser.constants';
 import { UpdateScheduleStatusDto } from './dto/req/update-schedule-status.dto';
 import { BulkUpdateRepairCheckDto } from './dto/req/bulk-update-repair-check.dto';
+import { type Response } from 'express';
 
 @UseInterceptors(ClassSerializerInterceptor)
 @Controller('schedule')
@@ -385,14 +387,16 @@ export class ScheduleController {
   @UseGuards(AdminGuard)
   @Get(':uuid/documents')
   async downloadInspectionDocuments(
+    @Res() res: Response,
     @Param('uuid', ParseUUIDPipe) scheduleUuid: string,
   ): Promise<StreamableFile> {
-    return new StreamableFile(
-      await this.scheduleService.downloadInspectionDocuments(scheduleUuid),
-      {
-        type: 'application/pdf',
-        disposition: 'attachment',
-      },
-    );
+    const { pages, buffer } =
+      await this.scheduleService.downloadInspectionDocuments(scheduleUuid);
+    res.setHeader('Content-Length', buffer.length.toString());
+    res.setHeader('X-Total-Pages', pages.toString());
+    return new StreamableFile(buffer, {
+      type: 'application/pdf',
+      disposition: 'attachment',
+    });
   }
 }

--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -387,7 +387,7 @@ export class ScheduleController {
   @UseGuards(AdminGuard)
   @Get(':uuid/documents')
   async downloadInspectionDocuments(
-    @Res() res: Response,
+    @Res({ passthrough: true }) res: Response,
     @Param('uuid', ParseUUIDPipe) scheduleUuid: string,
   ): Promise<StreamableFile> {
     const { pages, buffer } =

--- a/src/schedule/schedule.service.ts
+++ b/src/schedule/schedule.service.ts
@@ -857,7 +857,9 @@ export class ScheduleService {
     }
   }
 
-  async downloadInspectionDocuments(scheduleUuid: string): Promise<Buffer> {
+  async downloadInspectionDocuments(
+    scheduleUuid: string,
+  ): Promise<{ pages: number; buffer: Buffer }> {
     const schedule =
       await this.moveOutScheduleRepository.findMoveOutScheduleWithUuid(
         scheduleUuid,
@@ -885,6 +887,9 @@ export class ScheduleService {
       }
     }
     const out = await merged.save();
-    return Buffer.from(out);
+    return {
+      pages: documents.length,
+      buffer: Buffer.from(out),
+    };
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 검사 문서 다운로드 기능의 응답 처리를 개선했습니다.
  * 다운로드 응답에 총 페이지 수를 포함하여 전달합니다.
  * HTTP 응답 헤더에 파일 크기(Content-Length) 및 페이지 수(X-Total-Pages) 메타데이터를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->