### PR TITLE
feat: remove schedule

### DIFF
--- a/libs/database/src/repositories/move-out-schedule.repository.ts
+++ b/libs/database/src/repositories/move-out-schedule.repository.ts
@@ -286,4 +286,20 @@ export class MoveOutScheduleRepository {
         throw new InternalServerErrorException('Unknown Error');
       });
   }
+
+  async deleteMoveOutScheduleByUuid(uuid: string): Promise<MoveOutSchedule> {
+    return await this.databaseService.moveOutSchedule
+      .delete({
+        where: { uuid },
+      })
+      .catch((error) => {
+        if (error instanceof Prisma.PrismaClientKnownRequestError) {
+          if (error.code === 'P2025') {
+            throw new NotFoundException(`Move out schedule not found`);
+          }
+        }
+        this.logger.error(`deleteMoveOutScheduleByUuid error: ${error}`);
+        throw new InternalServerErrorException('Unknown Error');
+      });
+  }
 }

--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -15,6 +15,7 @@ import {
   Query,
   StreamableFile,
   Res,
+  Delete,
 } from '@nestjs/common';
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
 import {
@@ -398,5 +399,25 @@ export class ScheduleController {
       type: 'application/pdf',
       disposition: 'attachment',
     });
+  }
+
+  @ApiOperation({
+    summary: 'Remove Move Out Schedule',
+    description: 'Remove a specific move out schedule by UUID.',
+  })
+  @ApiNoContentResponse({
+    description: 'The move out schedule has been successfully removed.',
+  })
+  @ApiNotFoundResponse({ description: 'Not Found', type: ErrorDto })
+  @ApiBadRequestResponse({ description: 'Invalid UUID format' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  @ApiBearerAuth('admin')
+  @UseGuards(AdminGuard)
+  @Delete(':uuid')
+  async removeMoveOutSchedule(
+    @Param('uuid', ParseUUIDPipe) uuid: string,
+  ): Promise<void> {
+    return await this.scheduleService.removeMoveOutSchedule(uuid);
   }
 }

--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -16,6 +16,7 @@ import {
   StreamableFile,
   Res,
   Delete,
+  HttpStatus,
 } from '@nestjs/common';
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
 import {
@@ -411,10 +412,15 @@ export class ScheduleController {
   @ApiNotFoundResponse({ description: 'Not Found', type: ErrorDto })
   @ApiBadRequestResponse({ description: 'Invalid UUID format' })
   @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiForbiddenResponse({
+    description:
+      'Move out schedule can be removed only when the status is CANCELED or COMPLETED.',
+  })
   @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
   @ApiBearerAuth('admin')
   @UseGuards(AdminGuard)
   @Delete(':uuid')
+  @HttpCode(HttpStatus.NO_CONTENT)
   async removeMoveOutSchedule(
     @Param('uuid', ParseUUIDPipe) uuid: string,
   ): Promise<void> {

--- a/src/schedule/schedule.service.ts
+++ b/src/schedule/schedule.service.ts
@@ -892,4 +892,8 @@ export class ScheduleService {
       buffer: Buffer.from(out),
     };
   }
+
+  async removeMoveOutSchedule(uuid: string): Promise<void> {
+    await this.moveOutScheduleRepository.deleteMoveOutScheduleByUuid(uuid);
+  }
 }

--- a/src/schedule/schedule.service.ts
+++ b/src/schedule/schedule.service.ts
@@ -894,6 +894,16 @@ export class ScheduleService {
   }
 
   async removeMoveOutSchedule(uuid: string): Promise<void> {
+    const schedule =
+      await this.moveOutScheduleRepository.findMoveOutScheduleWithUuid(uuid);
+    if (
+      schedule.status !== ScheduleStatus.CANCELED &&
+      schedule.status !== ScheduleStatus.COMPLETED
+    ) {
+      throw new ForbiddenException(
+        'Move out schedule can be removed only when the status is CANCELED or COMPLETED.',
+      );
+    }
     await this.moveOutScheduleRepository.deleteMoveOutScheduleByUuid(uuid);
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이동 예정 일정을 UUID로 식별하여 삭제할 수 있는 새로운 API 엔드포인트가 추가되었습니다. 이 기능은 관리자 인증으로 보호되며, 성공 시 204 응답을 반환합니다. 존재하지 않는 일정을 삭제하려고 할 때는 404 오류가 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->