### PR TITLE
fix: deduplicate active applications before creating unique index

### DIFF
--- a/prisma/migrations/20260514094930_add_unique_active_application_status/migration.sql
+++ b/prisma/migrations/20260514094930_add_unique_active_application_status/migration.sql
@@ -2,6 +2,23 @@
 -- Active means deleted_at IS NULL and status is NULL or PENDING_NO_SHOW.
 DROP INDEX IF EXISTS "unique_active_application";
 
+WITH ranked_active_applications AS (
+  SELECT
+    "uuid",
+    ROW_NUMBER() OVER (
+      PARTITION BY "inspection_target_info_uuid"
+      ORDER BY "created_at" DESC, "uuid" DESC
+    ) AS row_num
+  FROM "inspection_application"
+  WHERE "deleted_at" IS NULL
+    AND ("status" IS NULL OR "status" = 'PENDING_NO_SHOW')
+)
+UPDATE "inspection_application" ia
+SET "status" = 'CANCELED'
+FROM ranked_active_applications raa
+WHERE ia."uuid" = raa."uuid"
+  AND raa.row_num > 1;
+
 CREATE UNIQUE INDEX "unique_active_application"
 ON "inspection_application" ("inspection_target_info_uuid")
 WHERE "deleted_at" IS NULL

--- a/prisma/migrations/20260517130627_add_unique_active_application_status/migration.sql
+++ b/prisma/migrations/20260517130627_add_unique_active_application_status/migration.sql
@@ -1,0 +1,25 @@
+-- Ensure only one active application exists per inspection target.
+-- Active means deleted_at IS NULL and status is NULL or PENDING_NO_SHOW.
+DROP INDEX IF EXISTS "unique_active_application";
+
+WITH ranked_active_applications AS (
+  SELECT
+    "uuid",
+    ROW_NUMBER() OVER (
+      PARTITION BY "inspection_target_info_uuid"
+      ORDER BY "created_at" DESC, "uuid" DESC
+    ) AS row_num
+  FROM "inspection_application"
+  WHERE "deleted_at" IS NULL
+    AND ("status" IS NULL OR "status" = 'PENDING_NO_SHOW')
+)
+UPDATE "inspection_application" ia
+SET "status" = 'CANCELED'
+FROM ranked_active_applications raa
+WHERE ia."uuid" = raa."uuid"
+  AND raa.row_num > 1;
+
+CREATE UNIQUE INDEX "unique_active_application"
+ON "inspection_application" ("inspection_target_info_uuid")
+WHERE "deleted_at" IS NULL
+  AND ("status" IS NULL OR "status" = 'PENDING_NO_SHOW');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 동일한 검사 대상에 대해 여러 활성 신청이 존재하는 상황을 자동으로 정리하여 데이터 일관성을 보장합니다. 가장 최신 신청만 유지하고 중복된 활성 신청들은 상태를 취소로 업데이트합니다.
  * 마이그레이션 실행 시 기존 인덱스 충돌을 예방하도록 사전 정리 과정을 추가해 재실행/환경 차이에서도 안정적으로 적용됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsainfoteam/house-moving-out-be/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->