### PR TITLE
feat: update student hash handling and repository methods

### DIFF
--- a/libs/database/src/encryption.service.ts
+++ b/libs/database/src/encryption.service.ts
@@ -141,12 +141,12 @@ export class EncryptionService implements OnModuleInit {
     }
   }
 
-  hash(name: string, studentNumber: string): string {
+  hash(studentNumber: string): string {
     this.ensureInitialized();
 
     return crypto
       .createHmac('sha256', this.pepper)
-      .update(`${name.toLowerCase().trim()}:${studentNumber}`)
+      .update(studentNumber.trim())
       .digest('hex');
   }
 

--- a/libs/database/src/repositories/inspection-target-info.repository.ts
+++ b/libs/database/src/repositories/inspection-target-info.repository.ts
@@ -108,7 +108,7 @@ export class InspectionTargetInfoRepository {
           inspectionTargetInfos.map(async (target) => {
             const uuid = crypto.randomUUID();
             const studentHashes = target.students.map((s) =>
-              this.encryptionService.hash(s.studentName, s.studentNumber),
+              this.encryptionService.hash(s.studentNumber),
             );
 
             const [
@@ -274,10 +274,9 @@ export class InspectionTargetInfoRepository {
 
   async findInspectionTargetInfoByUserInfo(
     studentNumber: string,
-    studentName: string,
     scheduleUuid: string,
   ): Promise<InspectionTargetInfo> {
-    const studentHash = this.encryptionService.hash(studentName, studentNumber);
+    const studentHash = this.encryptionService.hash(studentNumber);
 
     const target = await this.databaseService.inspectionTargetInfo
       .findFirstOrThrow({
@@ -305,11 +304,10 @@ export class InspectionTargetInfoRepository {
 
   async findInspectionTargetInfoByUserInfoInTx(
     studentNumber: string,
-    studentName: string,
     scheduleUuid: string,
     tx: PrismaTransaction,
   ): Promise<InspectionTargetInfo> {
-    const studentHash = this.encryptionService.hash(studentName, studentNumber);
+    const studentHash = this.encryptionService.hash(studentNumber);
 
     const target = await tx.inspectionTargetInfo
       .findFirstOrThrow({

--- a/libs/database/src/repositories/inspector.repository.ts
+++ b/libs/database/src/repositories/inspector.repository.ts
@@ -1,4 +1,5 @@
 import { Loggable } from '@lib/logger';
+import * as crypto from 'crypto';
 import {
   ConflictException,
   ForbiddenException,
@@ -74,10 +75,7 @@ export class InspectorRepository {
     inspector: InspectorDto | TemporaryInspectorDto,
     tx: PrismaTransaction,
   ) {
-    const studentHash = this.encryptionService.hash(
-      inspector.name,
-      inspector.studentNumber,
-    );
+    const studentHash = this.encryptionService.hash(inspector.studentNumber);
     const existingInspector = await tx.inspector.findUnique({
       where: { studentHash },
     });
@@ -104,7 +102,7 @@ export class InspectorRepository {
     return await (
       existingInspector
         ? tx.inspector.update({
-            where: { studentHash },
+            where: { uuid: existingInspector.uuid },
             data: {
               ...inspector,
               name: encryptedName!,
@@ -228,7 +226,7 @@ export class InspectorRepository {
     name: string,
     studentNumber: string,
   ): Promise<Inspector> {
-    const studentHash = this.encryptionService.hash(name, studentNumber);
+    const studentHash = this.encryptionService.hash(studentNumber);
 
     return await this.databaseService.inspector
       .findFirstOrThrow({
@@ -253,6 +251,12 @@ export class InspectorRepository {
         }
         this.logger.error(`findInspectorByUserInfo error: ${error}`);
         throw new InternalServerErrorException('Unknown Error');
+      })
+      .then((inspector) => {
+        if (inspector.name !== name) {
+          throw new NotFoundException('Inspector not found');
+        }
+        return inspector;
       });
   }
 
@@ -261,7 +265,7 @@ export class InspectorRepository {
     studentNumber: string,
     scheduleUuid: string,
   ): Promise<boolean> {
-    const studentHash = this.encryptionService.hash(name, studentNumber);
+    const studentHash = this.encryptionService.hash(studentNumber);
 
     return await this.databaseService.inspector
       .findFirst({
@@ -270,19 +274,19 @@ export class InspectorRepository {
           schedules: { some: { scheduleUuid } },
         },
       })
-      .then((inspector) => !!inspector)
       .catch((error) => {
         if (error instanceof Prisma.PrismaClientKnownRequestError) {
           this.logger.error(
-            `existsInspectorInScheduleByUserInfo prisma error: ${error.message}`,
+            `existsInspectorInScheduleByStudentNumber prisma error: ${error.message}`,
           );
           throw new InternalServerErrorException('Database Error');
         }
         this.logger.error(
-          `existsInspectorInScheduleByUserInfo error: ${error}`,
+          `existsInspectorInScheduleByStudentNumber error: ${error}`,
         );
         throw new InternalServerErrorException('Unknown Error');
-      });
+      })
+      .then((inspector) => inspector?.name === name);
   }
 
   async findAvailableInspectorBySlotUuidInTx(
@@ -293,7 +297,7 @@ export class InspectorRepository {
     tx: PrismaTransaction,
   ): Promise<Inspector> {
     const studentHashesToExclude = residentStudents.map((resident) =>
-      this.encryptionService.hash(resident.name, resident.studentNumber),
+      this.encryptionService.hash(resident.studentNumber),
     );
 
     const inspectorExclusionCondition =

--- a/libs/database/src/repositories/user.repository.ts
+++ b/libs/database/src/repositories/user.repository.ts
@@ -50,7 +50,7 @@ export class UserRepository {
     name: string,
     studentNumber: string,
   ): Promise<User> {
-    const studentHash = this.encryptionService.hash(name, studentNumber);
+    const studentHash = this.encryptionService.hash(studentNumber);
 
     return await this.databaseService.user
       .findFirst({
@@ -77,7 +77,22 @@ export class UserRepository {
         }
         this.logger.error(`findUserByNameAndStudentNumber error: ${error}`);
         throw new InternalServerErrorException('Unknown Error');
+      })
+      .then((user) => {
+        if (user.name !== name) {
+          throw new NotFoundException('User not found');
+        }
+        return user;
       });
+  }
+
+  private async findExistingUserByStudentHashInTx(
+    studentHash: string,
+    tx: PrismaTransaction,
+  ) {
+    return await tx.user.findUnique({
+      where: { studentHash },
+    });
   }
 
   async upsertUserInTx(
@@ -89,10 +104,11 @@ export class UserRepository {
     }: Pick<User, 'name' | 'email' | 'phoneNumber' | 'studentNumber'>,
     tx: PrismaTransaction,
   ): Promise<User> {
-    const studentHash = this.encryptionService.hash(name, studentNumber);
-    const existingUser = await tx.user.findUnique({
-      where: { studentHash },
-    });
+    const studentHash = this.encryptionService.hash(studentNumber);
+    const existingUser = await this.findExistingUserByStudentHashInTx(
+      studentHash,
+      tx,
+    );
     const uuid = existingUser?.uuid ?? crypto.randomUUID();
 
     const [
@@ -119,24 +135,29 @@ export class UserRepository {
       ),
     ]);
 
-    return await tx.user
-      .upsert({
-        where: { uuid, studentHash },
-        create: {
-          uuid,
-          studentHash,
-          name: encryptedName!,
-          email: encryptedEmail!,
-          phoneNumber: encryptedPhoneNumber!,
-          studentNumber: encryptedStudentNumber!,
-        },
-        update: {
-          name: encryptedName!,
-          email: encryptedEmail!,
-          phoneNumber: encryptedPhoneNumber!,
-          studentNumber: encryptedStudentNumber!,
-        },
-      })
+    return await (
+      existingUser
+        ? tx.user.update({
+            where: { uuid: existingUser.uuid },
+            data: {
+              studentHash,
+              name: encryptedName!,
+              email: encryptedEmail!,
+              phoneNumber: encryptedPhoneNumber!,
+              studentNumber: encryptedStudentNumber!,
+            },
+          })
+        : tx.user.create({
+            data: {
+              uuid,
+              studentHash,
+              name: encryptedName!,
+              email: encryptedEmail!,
+              phoneNumber: encryptedPhoneNumber!,
+              studentNumber: encryptedStudentNumber!,
+            },
+          })
+    )
       .then(async (user) => await this.encryptionService.decryptUser(user))
       .catch((error) => {
         if (error instanceof Prisma.PrismaClientKnownRequestError) {

--- a/loadtest/seed-users.ts
+++ b/loadtest/seed-users.ts
@@ -151,13 +151,13 @@ async function readInputUsers(inputPath: string): Promise<InputUser[]> {
   const duplicates = new Set<string>();
   const seen = new Set<string>();
   for (const u of users) {
-    const key = `${u.name.toLowerCase().trim()}:${u.studentNumber}`;
+    const key = u.studentNumber.trim();
     if (seen.has(key)) duplicates.add(key);
     seen.add(key);
   }
   if (duplicates.size > 0) {
     throw new Error(
-      `Duplicate (name, studentNumber) pairs in input: ${Array.from(duplicates)
+      `Duplicate studentNumber values in input: ${Array.from(duplicates)
         .slice(0, 5)
         .join(', ')}${duplicates.size > 5 ? ' ...' : ''}`,
     );
@@ -241,7 +241,7 @@ async function main() {
 
     const results = await Promise.all(
       seedList.map(async ({ name, studentNumber, email, phoneNumber }) => {
-        const studentHash = encryptionService.hash(name, studentNumber);
+        const studentHash = encryptionService.hash(studentNumber);
 
         const existing = await prisma.user.findUnique({
           where: { studentHash },
@@ -270,33 +270,43 @@ async function main() {
           ),
         ]);
 
-        const user = await prisma.user.upsert({
-          where: { studentHash },
-          create: {
-            uuid,
-            studentHash,
-            name: encryptedName!,
-            email: encryptedEmail!,
-            phoneNumber: encryptedPhoneNumber!,
-            studentNumber: encryptedStudentNumber!,
-            role: options.role,
-          },
-          update: {
-            name: encryptedName!,
-            email: encryptedEmail!,
-            phoneNumber: encryptedPhoneNumber!,
-            studentNumber: encryptedStudentNumber!,
-            role: options.role,
-            deletedAt: null,
-          },
-          select: {
-            uuid: true,
-            studentHash: true,
-            role: true,
-            createdAt: true,
-            updatedAt: true,
-          },
-        });
+        const user = existing
+          ? await prisma.user.update({
+              where: { uuid: existing.uuid },
+              data: {
+                name: encryptedName!,
+                email: encryptedEmail!,
+                phoneNumber: encryptedPhoneNumber!,
+                studentNumber: encryptedStudentNumber!,
+                role: options.role,
+                deletedAt: null,
+              },
+              select: {
+                uuid: true,
+                studentHash: true,
+                role: true,
+                createdAt: true,
+                updatedAt: true,
+              },
+            })
+          : await prisma.user.create({
+              data: {
+                uuid,
+                studentHash,
+                name: encryptedName!,
+                email: encryptedEmail!,
+                phoneNumber: encryptedPhoneNumber!,
+                studentNumber: encryptedStudentNumber!,
+                role: options.role,
+              },
+              select: {
+                uuid: true,
+                studentHash: true,
+                role: true,
+                createdAt: true,
+                updatedAt: true,
+              },
+            });
 
         await prisma.userRefreshToken.deleteMany({
           where: { userUuid: user.uuid },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "loadtest:seed-users": "bun run loadtest/seed-users.ts",
+    "backfill:student-hash": "bun run scripts/backfill-student-hash.ts",
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",

--- a/scripts/backfill-student-hash.ts
+++ b/scripts/backfill-student-hash.ts
@@ -1,0 +1,367 @@
+import 'dotenv/config';
+/**
+ * Recomputes student_hash / student_hashes using student-number-only hashing.
+ *
+ * Deployment order for existing environments:
+ * 1. bun run backfill:student-hash -- --dry-run
+ * 2. bun run backfill:student-hash
+ * 3. Deploy application code that matches by student number only
+ *
+ * Requires the same AWS/KMS env vars as the application (see loadtest/seed-users.ts).
+ */
+import { ConfigService } from '@nestjs/config';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from 'generated/prisma/client';
+import { EncryptionService } from '../libs/database/src/encryption.service';
+import {
+  ENCRYPTION_PURPOSE,
+  EncryptionPurpose,
+} from '../libs/database/src/constants/encryption.constants';
+
+type BackfillOptions = {
+  dryRun: boolean;
+  batchSize: number;
+};
+
+type BackfillSummary = {
+  users: { updated: number; skipped: number; errors: number };
+  targets: { updated: number; skipped: number; errors: number };
+  inspectors: { updated: number; skipped: number; errors: number };
+};
+
+function parseArgs(argv: string[]): BackfillOptions {
+  const args = new Map<string, string>();
+  for (let i = 0; i < argv.length; i += 1) {
+    const raw = argv[i];
+    if (!raw?.startsWith('--')) continue;
+    const key = raw.slice(2);
+    const value = argv[i + 1];
+    if (!value || value.startsWith('--')) {
+      args.set(key, 'true');
+      continue;
+    }
+    args.set(key, value);
+    i += 1;
+  }
+
+  return {
+    dryRun: args.get('dry-run') === 'true',
+    batchSize: Number(args.get('batch-size') ?? '100'),
+  };
+}
+
+function createSummary(): BackfillSummary {
+  return {
+    users: { updated: 0, skipped: 0, errors: 0 },
+    targets: { updated: 0, skipped: 0, errors: 0 },
+    inspectors: { updated: 0, skipped: 0, errors: 0 },
+  };
+}
+
+async function backfillUsers(
+  prisma: PrismaClient,
+  encryptionService: EncryptionService,
+  options: BackfillOptions,
+  summary: BackfillSummary,
+) {
+  const assignedHashes = new Set<string>();
+  let cursor: string | undefined;
+
+  while (true) {
+    const users = await prisma.user.findMany({
+      take: options.batchSize,
+      ...(cursor ? { skip: 1, cursor: { uuid: cursor } } : {}),
+      orderBy: { uuid: 'asc' },
+      select: {
+        uuid: true,
+        studentHash: true,
+        studentNumber: true,
+      },
+    });
+
+    if (users.length === 0) break;
+    cursor = users[users.length - 1]?.uuid;
+
+    for (const user of users) {
+      try {
+        const studentNumber = await encryptionService.decrypt(
+          user.studentNumber,
+          ENCRYPTION_PURPOSE.USER.STUDENT_NUMBER,
+          user.uuid,
+        );
+
+        if (!studentNumber) {
+          console.error(`[user] skip uuid=${user.uuid}: empty studentNumber`);
+          summary.users.errors += 1;
+          continue;
+        }
+
+        const newHash = encryptionService.hash(studentNumber);
+        if (user.studentHash === newHash) {
+          assignedHashes.add(newHash);
+          summary.users.skipped += 1;
+          continue;
+        }
+
+        if (assignedHashes.has(newHash)) {
+          console.error(
+            `[user] skip uuid=${user.uuid}: duplicate studentNumber hash conflict`,
+          );
+          summary.users.errors += 1;
+          continue;
+        }
+
+        const conflictingUser = await prisma.user.findUnique({
+          where: { studentHash: newHash },
+          select: { uuid: true },
+        });
+        if (conflictingUser && conflictingUser.uuid !== user.uuid) {
+          console.error(
+            `[user] skip uuid=${user.uuid}: studentHash already assigned to uuid=${conflictingUser.uuid}`,
+          );
+          summary.users.errors += 1;
+          continue;
+        }
+
+        if (!options.dryRun) {
+          await prisma.user.update({
+            where: { uuid: user.uuid },
+            data: { studentHash: newHash },
+          });
+        }
+
+        assignedHashes.add(newHash);
+        summary.users.updated += 1;
+      } catch (error) {
+        console.error(`[user] error uuid=${user.uuid}:`, error);
+        summary.users.errors += 1;
+      }
+    }
+  }
+}
+
+async function backfillInspectors(
+  prisma: PrismaClient,
+  encryptionService: EncryptionService,
+  options: BackfillOptions,
+  summary: BackfillSummary,
+) {
+  const assignedHashes = new Set<string>();
+  let cursor: string | undefined;
+
+  while (true) {
+    const inspectors = await prisma.inspector.findMany({
+      take: options.batchSize,
+      ...(cursor ? { skip: 1, cursor: { uuid: cursor } } : {}),
+      orderBy: { uuid: 'asc' },
+      select: {
+        uuid: true,
+        studentHash: true,
+        studentNumber: true,
+      },
+    });
+
+    if (inspectors.length === 0) break;
+    cursor = inspectors[inspectors.length - 1]?.uuid;
+
+    for (const inspector of inspectors) {
+      try {
+        const studentNumber = await encryptionService.decrypt(
+          inspector.studentNumber,
+          ENCRYPTION_PURPOSE.INSPECTOR.STUDENT_NUMBER,
+          inspector.uuid,
+        );
+
+        if (!studentNumber) {
+          console.error(
+            `[inspector] skip uuid=${inspector.uuid}: empty studentNumber`,
+          );
+          summary.inspectors.errors += 1;
+          continue;
+        }
+
+        const newHash = encryptionService.hash(studentNumber);
+        if (inspector.studentHash === newHash) {
+          assignedHashes.add(newHash);
+          summary.inspectors.skipped += 1;
+          continue;
+        }
+
+        if (assignedHashes.has(newHash)) {
+          console.error(
+            `[inspector] skip uuid=${inspector.uuid}: duplicate studentNumber hash conflict`,
+          );
+          summary.inspectors.errors += 1;
+          continue;
+        }
+
+        const conflictingInspector = await prisma.inspector.findUnique({
+          where: { studentHash: newHash },
+          select: { uuid: true },
+        });
+        if (
+          conflictingInspector &&
+          conflictingInspector.uuid !== inspector.uuid
+        ) {
+          console.error(
+            `[inspector] skip uuid=${inspector.uuid}: studentHash already assigned to uuid=${conflictingInspector.uuid}`,
+          );
+          summary.inspectors.errors += 1;
+          continue;
+        }
+
+        if (!options.dryRun) {
+          await prisma.inspector.update({
+            where: { uuid: inspector.uuid },
+            data: { studentHash: newHash },
+          });
+        }
+
+        assignedHashes.add(newHash);
+        summary.inspectors.updated += 1;
+      } catch (error) {
+        console.error(`[inspector] error uuid=${inspector.uuid}:`, error);
+        summary.inspectors.errors += 1;
+      }
+    }
+  }
+}
+
+async function backfillTargets(
+  prisma: PrismaClient,
+  encryptionService: EncryptionService,
+  options: BackfillOptions,
+  summary: BackfillSummary,
+) {
+  let cursor: string | undefined;
+
+  while (true) {
+    const targets = await prisma.inspectionTargetInfo.findMany({
+      take: options.batchSize,
+      ...(cursor ? { skip: 1, cursor: { uuid: cursor } } : {}),
+      orderBy: { uuid: 'asc' },
+      select: {
+        uuid: true,
+        studentHashes: true,
+        student1StudentNumber: true,
+        student2StudentNumber: true,
+        student3StudentNumber: true,
+      },
+    });
+
+    if (targets.length === 0) break;
+    cursor = targets[targets.length - 1]?.uuid;
+
+    for (const target of targets) {
+      try {
+        const studentNumbers: string[] = [];
+        const encryptedEntries: Array<{
+          encryptedStudentNumber: string;
+          purpose: EncryptionPurpose;
+        }> = [];
+
+        if (target.student1StudentNumber) {
+          encryptedEntries.push({
+            encryptedStudentNumber: target.student1StudentNumber,
+            purpose: ENCRYPTION_PURPOSE.TARGET.STUDENT1_STUDENT_NUMBER,
+          });
+        }
+        if (target.student2StudentNumber) {
+          encryptedEntries.push({
+            encryptedStudentNumber: target.student2StudentNumber,
+            purpose: ENCRYPTION_PURPOSE.TARGET.STUDENT2_STUDENT_NUMBER,
+          });
+        }
+        if (target.student3StudentNumber) {
+          encryptedEntries.push({
+            encryptedStudentNumber: target.student3StudentNumber,
+            purpose: ENCRYPTION_PURPOSE.TARGET.STUDENT3_STUDENT_NUMBER,
+          });
+        }
+
+        const decryptedStudentNumbers = await Promise.all(
+          encryptedEntries.map(({ encryptedStudentNumber, purpose }) =>
+            encryptionService.decrypt(
+              encryptedStudentNumber,
+              purpose,
+              target.uuid,
+            ),
+          ),
+        );
+
+        for (const studentNumber of decryptedStudentNumbers) {
+          if (studentNumber) {
+            studentNumbers.push(studentNumber);
+          }
+        }
+
+        const newHashes = [
+          ...new Set(studentNumbers.map((n) => encryptionService.hash(n))),
+        ];
+
+        const isUnchanged =
+          newHashes.length === target.studentHashes.length &&
+          newHashes.every((hash) => target.studentHashes.includes(hash));
+
+        if (isUnchanged) {
+          summary.targets.skipped += 1;
+          continue;
+        }
+
+        if (!options.dryRun) {
+          await prisma.inspectionTargetInfo.update({
+            where: { uuid: target.uuid },
+            data: { studentHashes: newHashes },
+          });
+        }
+
+        summary.targets.updated += 1;
+      } catch (error) {
+        console.error(`[target] error uuid=${target.uuid}:`, error);
+        summary.targets.errors += 1;
+      }
+    }
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const summary = createSummary();
+  const configService = new ConfigService(process.env);
+  const connectionString = configService.getOrThrow<string>('DATABASE_URL');
+  const adapter = new PrismaPg({ connectionString });
+  const prisma = new PrismaClient({ adapter });
+  const encryptionService = new EncryptionService(configService);
+
+  try {
+    await encryptionService.onModuleInit();
+    await prisma.$connect();
+
+    console.log(
+      `Starting studentHash backfill (dryRun=${options.dryRun}, batchSize=${options.batchSize})`,
+    );
+
+    await backfillUsers(prisma, encryptionService, options, summary);
+    await backfillInspectors(prisma, encryptionService, options, summary);
+    await backfillTargets(prisma, encryptionService, options, summary);
+
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          dryRun: options.dryRun,
+          summary,
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/application/application.service.ts
+++ b/src/application/application.service.ts
@@ -82,7 +82,6 @@ export class ApplicationService {
         const inspectionTargetInfo =
           await this.inspectionTargetInfoRepository.findInspectionTargetInfoByUserInfoInTx(
             user.studentNumber,
-            user.name,
             schedule.uuid,
             tx,
           );
@@ -195,7 +194,6 @@ export class ApplicationService {
     const targetInfo =
       await this.inspectionTargetInfoRepository.findInspectionTargetInfoByUserInfo(
         user.studentNumber,
-        user.name,
         schedule.uuid,
       );
 
@@ -463,7 +461,6 @@ export class ApplicationService {
     const inspectionTargetInfo =
       await this.inspectionTargetInfoRepository.findInspectionTargetInfoByUserInfo(
         user.studentNumber,
-        user.name,
         schedule.uuid,
       );
     const application =

--- a/src/schedule/schedule.service.ts
+++ b/src/schedule/schedule.service.ts
@@ -513,7 +513,6 @@ export class ScheduleService {
       const targetInfo =
         await this.inspectionTargetInfoRepository.findInspectionTargetInfoByUserInfo(
           user.studentNumber,
-          user.name,
           schedule.uuid,
         );
 

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -7,6 +7,7 @@
   "include": [
     "src/**/*",
     "loadtest/**/*",
+    "scripts/**/*",
     "libs/**/*",
     "generated/**/*",
     "test/**/*"


### PR DESCRIPTION
- Added a new script for backfilling student hashes using only student numbers.
- Updated the `hash` method in `EncryptionService` to accept only student numbers.
- Refactored various repository methods to remove name dependency and use student numbers for hashing.
- Adjusted user and inspector repository methods to align with the new hashing strategy.
- Enhanced the `package.json` with a new script command for backfilling student hashes.
- Updated ESLint configuration to include scripts directory for type checking.