### PR TITLE
fix: update application status filtering in inspector queries

### DIFF
--- a/libs/database/src/repositories/inspector.repository.ts
+++ b/libs/database/src/repositories/inspector.repository.ts
@@ -11,6 +11,7 @@ import {
 import { DatabaseService } from '../database.service';
 import { EncryptionService } from '../encryption.service';
 import {
+  ApplicationStatus,
   Gender,
   InspectionApplication,
   Inspector,
@@ -190,7 +191,20 @@ export class InspectorRepository {
         where: { uuid, schedules: { some: { scheduleUuid } } },
         include: {
           applications: {
-            where: { deletedAt: null },
+            where: {
+              deletedAt: null,
+              OR: [
+                { status: null },
+                {
+                  status: {
+                    notIn: [
+                      ApplicationStatus.CANCELED,
+                      ApplicationStatus.NO_SHOW_CANCELED,
+                    ],
+                  },
+                },
+              ],
+            },
           },
           availableSlots: true,
           schedules: {
@@ -325,6 +339,7 @@ export class InspectorRepository {
           WHERE ia.inspector_uuid = i.uuid 
             AND ia.inspection_slot_uuid = ${inspectionSlotUuid}
             AND ia.deleted_at IS NULL
+            AND (ia.status IS NULL OR ia.status NOT IN ('CANCELED', 'NO_SHOW_CANCELED'))
         ) < ${this.MAX_APPLICATIONS_PER_INSPECTOR}
       ORDER BY (
         SELECT COUNT(*) 
@@ -332,6 +347,7 @@ export class InspectorRepository {
         INNER JOIN inspection_slot AS slot ON slot.uuid = ia.inspection_slot_uuid
         WHERE ia.inspector_uuid = i.uuid
           AND ia.deleted_at IS NULL
+          AND (ia.status IS NULL OR ia.status NOT IN ('CANCELED', 'NO_SHOW_CANCELED'))
           AND slot.schedule_uuid = ${scheduleUuid}
       ) ASC, random()
       LIMIT 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 인스펙터 예약 가용성 계산 시 취소 및 노쇼 취소 상태의 예약을 더 이상 포함하지 않도록 수정했습니다. 예약 일정 내 인스펙터 선정이 보다 정확해집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->