### PR TITLE
feat: add includeCanceled option to application list

### DIFF
--- a/libs/database/src/repositories/inspection-application.repository.ts
+++ b/libs/database/src/repositories/inspection-application.repository.ts
@@ -390,6 +390,7 @@ export class InspectionApplicationRepository {
     inspectorUuid?: string,
     slotUuid?: string,
     includePast?: boolean,
+    includeCanceled?: boolean,
   ): Promise<ApplicationInfo[]> {
     return await this.databaseService.inspectionApplication
       .findMany({
@@ -401,6 +402,21 @@ export class InspectionApplicationRepository {
           inspectorUuid,
           inspectionSlotUuid: slotUuid,
           deletedAt: null,
+          ...(includeCanceled
+            ? {}
+            : {
+                OR: [
+                  { status: null },
+                  {
+                    status: {
+                      notIn: [
+                        ApplicationStatus.CANCELED,
+                        ApplicationStatus.NO_SHOW_CANCELED,
+                      ],
+                    },
+                  },
+                ],
+              }),
         },
         include: {
           user: true,
@@ -486,6 +502,7 @@ export class InspectionApplicationRepository {
     inspectorUuid?: string,
     slotUuid?: string,
     includePast?: boolean,
+    includeCanceled?: boolean,
   ): Promise<number> {
     return await this.databaseService.inspectionApplication
       .count({
@@ -497,6 +514,21 @@ export class InspectionApplicationRepository {
           inspectorUuid,
           inspectionSlotUuid: slotUuid,
           deletedAt: null,
+          ...(includeCanceled
+            ? {}
+            : {
+                OR: [
+                  { status: null },
+                  {
+                    status: {
+                      notIn: [
+                        ApplicationStatus.CANCELED,
+                        ApplicationStatus.NO_SHOW_CANCELED,
+                      ],
+                    },
+                  },
+                ],
+              }),
         },
       })
       .catch((error) => {

--- a/libs/database/src/repositories/inspection-application.repository.ts
+++ b/libs/database/src/repositories/inspection-application.repository.ts
@@ -389,8 +389,8 @@ export class InspectionApplicationRepository {
     scheduleUuid: string,
     inspectorUuid?: string,
     slotUuid?: string,
-    includePast?: boolean,
-    includeCanceled?: boolean,
+    includePast: boolean = true,
+    includeCanceled: boolean = true,
   ): Promise<ApplicationInfo[]> {
     return await this.databaseService.inspectionApplication
       .findMany({

--- a/src/schedule/dto/req/application-list-query.dto.ts
+++ b/src/schedule/dto/req/application-list-query.dto.ts
@@ -47,4 +47,13 @@ export class ApplicationListQueryDto {
   @Transform(({ value }) => value === 'true' || value === true)
   @IsBoolean()
   includePast?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Whether to include canceled inspection applications.',
+    example: true,
+  })
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  @IsBoolean()
+  includeCanceled?: boolean;
 }

--- a/src/schedule/schedule.service.ts
+++ b/src/schedule/schedule.service.ts
@@ -192,6 +192,7 @@ export class ScheduleService {
       inspectorUuid,
       slotUuid,
       includePast,
+      includeCanceled,
     }: ApplicationListQueryDto,
     scheduleUuid: string,
   ): Promise<ApplicationListResDto> {
@@ -202,13 +203,15 @@ export class ScheduleService {
         scheduleUuid,
         inspectorUuid,
         slotUuid,
-        includePast ?? true, // hotfix: 프론트엔드에 체크박스 추가 후 false 로 변경
+        includePast ?? true,
+        includeCanceled ?? true,
       ),
       this.inspectionApplicationRepository.countApplications(
         scheduleUuid,
         inspectorUuid,
         slotUuid,
-        includePast ?? true, // hotfix: 프론트엔드에 체크박스 추가 후 false 로 변경
+        includePast ?? true,
+        includeCanceled ?? true,
       ),
     ]);
     return new ApplicationListResDto(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 애플리케이션 목록 조회 시 “취소됨” 상태 항목을 포함할지 여부를 제어할 수 있도록 개선되었습니다.
  * 요청 쿼리에 `includeCanceled` 값을 추가해, `true`로 설정하면 취소 상태를 포함하고 `false`로 설정하면 제외할 수 있습니다. (미지정 시 기본 포함 동작)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->